### PR TITLE
Filter private networks from crawls.

### DIFF
--- a/src/filters.spec.ts
+++ b/src/filters.spec.ts
@@ -1,0 +1,29 @@
+import PeerInfo from 'peer-info'
+import PeerId from 'peer-id'
+import { peerHasOnlyPublicAddresses, peerHasOnlyPrivateAddresses } from './filters'
+import assert from 'assert'
+import Multiaddr from 'multiaddr'
+
+describe('filters', () => {
+  it('peers', async () => {
+    const unConnectedPeer = await PeerInfo.create(await PeerId.create({ keyType: 'secp256k1' }))
+    assert(peerHasOnlyPublicAddresses(unConnectedPeer) == false)
+    assert(peerHasOnlyPrivateAddresses(unConnectedPeer) == false)
+
+    const privatePeer = await PeerInfo.create(await PeerId.create({ keyType: 'secp256k1' }))
+    privatePeer.multiaddrs.add(new Multiaddr('/ip4/127.0.0.1/tcp/9090'))
+    assert(peerHasOnlyPublicAddresses(privatePeer) == false)
+    assert(peerHasOnlyPrivateAddresses(privatePeer) == true)
+
+    const publicPeer = await PeerInfo.create(await PeerId.create({ keyType: 'secp256k1' }))
+    publicPeer.multiaddrs.add(new Multiaddr('/ip4/123.4.56.7/tcp/9090'))
+    assert(peerHasOnlyPublicAddresses(publicPeer) == true)
+    assert(peerHasOnlyPrivateAddresses(publicPeer) == false)
+
+    const mixedPeer = await PeerInfo.create(await PeerId.create({ keyType: 'secp256k1' }))
+    mixedPeer.multiaddrs.add(new Multiaddr('/ip4/123.4.56.7/tcp/9090'))
+    mixedPeer.multiaddrs.add(new Multiaddr('/ip4/127.0.0.1/tcp/9090'))
+    assert(peerHasOnlyPublicAddresses(mixedPeer) == false)
+    assert(peerHasOnlyPrivateAddresses(mixedPeer) == false)
+  })
+})

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,2 +1,18 @@
+import PeerInfo from 'peer-info'
+
 // This should filter IP4's from private networks, as defined by RFC1918
 export const PRIVATE_NETS = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/
+
+export const peerHasOnlyPrivateAddresses = (peer: PeerInfo): boolean => {
+  return (
+    peer.multiaddrs.size > 0 &&
+    peer.multiaddrs.toArray().filter((ma) => !ma.nodeAddress().address.match(PRIVATE_NETS)).length == 0
+  )
+}
+
+export const peerHasOnlyPublicAddresses = (peer: PeerInfo): boolean => {
+  return (
+    peer.multiaddrs.size > 0 &&
+    peer.multiaddrs.toArray().filter((ma) => ma.nodeAddress().address.match(PRIVATE_NETS)).length == 0
+  )
+}

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,18 +1,17 @@
 import PeerInfo from 'peer-info'
+import Multiaddr from 'multiaddr'
 
 // This should filter IP4's from private networks, as defined by RFC1918
 export const PRIVATE_NETS = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/
 
 export const peerHasOnlyPrivateAddresses = (peer: PeerInfo): boolean => {
-  return (
-    peer.multiaddrs.size > 0 &&
-    peer.multiaddrs.toArray().filter((ma) => !ma.nodeAddress().address.match(PRIVATE_NETS)).length == 0
-  )
+  return peer.multiaddrs.size > 0 && peer.multiaddrs.toArray().filter((ma) => !isOnPrivateNet(ma)).length == 0
 }
 
 export const peerHasOnlyPublicAddresses = (peer: PeerInfo): boolean => {
-  return (
-    peer.multiaddrs.size > 0 &&
-    peer.multiaddrs.toArray().filter((ma) => ma.nodeAddress().address.match(PRIVATE_NETS)).length == 0
-  )
+  return peer.multiaddrs.size > 0 && peer.multiaddrs.toArray().filter(isOnPrivateNet).length == 0
+}
+
+export const isOnPrivateNet = (ma: Multiaddr): boolean => {
+  return Boolean(ma.nodeAddress().address.match(PRIVATE_NETS))
 }

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,0 +1,2 @@
+// This should filter IP4's from private networks, as defined by RFC1918
+export const PRIVATE_NETS = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/

--- a/src/network/crawler.spec.ts
+++ b/src/network/crawler.spec.ts
@@ -206,14 +206,9 @@ describe('test crawler', function () {
   })
   it('shouldIncludePeerInCrawlResponse', async () => {
     let m = (s) => new Multiaddr(s)
-    let p = async (s) => {
-      let x = await PeerInfo.create(await PeerId.create({ keyType: 'secp256k1' }))
-      x.multiaddrs.add(m(s))
-      return x
-    }
 
-    assert(shouldIncludePeerInCrawlResponse(await p('/ip4/123.4.5.6/tcp/5000'), m('/ip4/12.34.56.7/tcp/5000')))
-    assert(shouldIncludePeerInCrawlResponse(await p('/ip4/127.0.0.1/tcp/1000'), m('/ip4/127.0.0.1/tcp/5000')))
-    assert(!shouldIncludePeerInCrawlResponse(await p('/ip4/127.0.0.1/tcp/5000'), m('/ip4/12.34.56.7/tcp/5000')))
+    assert(shouldIncludePeerInCrawlResponse(m('/ip4/123.4.5.6/tcp/5000'), m('/ip4/12.34.56.7/tcp/5000')))
+    assert(shouldIncludePeerInCrawlResponse(m('/ip4/127.0.0.1/tcp/1000'), m('/ip4/127.0.0.1/tcp/5000')))
+    assert(!shouldIncludePeerInCrawlResponse(m('/ip4/127.0.0.1/tcp/5000'), m('/ip4/12.34.56.7/tcp/5000')))
   })
 })

--- a/src/network/crawler.spec.ts
+++ b/src/network/crawler.spec.ts
@@ -21,9 +21,13 @@ import { Crawler, CRAWL_TIMEOUT } from './crawler'
 import { Crawler as CrawlerInteraction } from '../interactions/network/crawler'
 import Multiaddr from 'multiaddr'
 import PeerStore, { BLACKLIST_TIMEOUT, BlacklistedEntry } from './peerStore'
+import { CrawlResponse, CrawlStatus } from '../messages'
 
 describe('test crawler', function () {
-  async function generateNode(options?: { timeoutIntentionally: boolean }): Promise<Hopr<HoprCoreConnector>> {
+  async function generateNode(
+    options?: { timeoutIntentionally: boolean },
+    addr = '/ip4/0.0.0.0/tcp/0'
+  ): Promise<Hopr<HoprCoreConnector>> {
     const node = (await libp2p.create({
       peerInfo: await PeerInfo.create(await PeerId.create({ keyType: 'secp256k1' })),
       modules: {
@@ -33,7 +37,7 @@ describe('test crawler', function () {
       },
     })) as Hopr<HoprCoreConnector>
 
-    node.peerInfo.multiaddrs.add(Multiaddr('/ip4/0.0.0.0/tcp/0'))
+    node.peerInfo.multiaddrs.add(Multiaddr(addr))
 
     await node.start()
 
@@ -177,19 +181,12 @@ describe('test crawler', function () {
     // )
 
     Alice.emit('peer:connect', Bob.peerInfo)
-
     await Alice.network.crawler.crawl()
-
     Bob.emit('peer:connect', Chris.peerInfo)
-
     await Alice.network.crawler.crawl()
-
     await new Promise((resolve) => setTimeout(resolve, 100))
-
     await Bob.stop()
-
     await Alice.network.crawler.crawl()
-
     await new Promise((resolve) => setTimeout(resolve, 200))
 
     timeoutCorrectly = true

--- a/src/network/crawler.spec.ts
+++ b/src/network/crawler.spec.ts
@@ -17,7 +17,7 @@ import chalk from 'chalk'
 import Hopr from '..'
 import HoprCoreConnector from '@hoprnet/hopr-core-connector-interface'
 import { Interactions } from '../interactions'
-import { Crawler, CRAWL_TIMEOUT } from './crawler'
+import { Crawler, CRAWL_TIMEOUT, shouldIncludePeerInCrawlResponse } from './crawler'
 import { Crawler as CrawlerInteraction } from '../interactions/network/crawler'
 import Multiaddr from 'multiaddr'
 import PeerStore, { BLACKLIST_TIMEOUT, BlacklistedEntry } from './peerStore'
@@ -203,5 +203,17 @@ describe('test crawler', function () {
       Bob.stop(),
       Chris.stop(),
     ])
+  })
+  it('shouldIncludePeerInCrawlResponse', async () => {
+    let m = (s) => new Multiaddr(s)
+    let p = async (s) => {
+      let x = await PeerInfo.create(await PeerId.create({ keyType: 'secp256k1' }))
+      x.multiaddrs.add(m(s))
+      return x
+    }
+
+    assert(shouldIncludePeerInCrawlResponse(await p('/ip4/123.4.5.6/tcp/5000'), m('/ip4/12.34.56.7/tcp/5000')))
+    assert(shouldIncludePeerInCrawlResponse(await p('/ip4/127.0.0.1/tcp/1000'), m('/ip4/127.0.0.1/tcp/5000')))
+    assert(!shouldIncludePeerInCrawlResponse(await p('/ip4/127.0.0.1/tcp/5000'), m('/ip4/12.34.56.7/tcp/5000')))
   })
 })

--- a/src/network/crawler.ts
+++ b/src/network/crawler.ts
@@ -11,22 +11,13 @@ import { CrawlResponse, CrawlStatus } from '../messages'
 import PeerId from 'peer-id'
 import type { Connection } from './transport/types'
 import type { Entry } from './peerStore'
-import { PRIVATE_NETS } from '../filters'
+import { peerHasOnlyPublicAddresses, peerHasOnlyPrivateAddresses, PRIVATE_NETS } from '../filters'
 import debug from 'debug'
 const log = debug('hopr-core:crawler')
 const verbose = debug('hopr-core:verbose:crawler')
 
 const MAX_PARALLEL_REQUESTS = 7
 export const CRAWL_TIMEOUT = 1 * 1000
-
-const peerHasOnlyPrivateAddresses = (peer: PeerInfo): boolean => {
-  return !(peer.multiaddrs.toArray().filter((ma) => !ma.nodeAddress().address.match(PRIVATE_NETS)).length > 0)
-}
-
-const peerHasOnlyPublicAddresses = (peer: PeerInfo): boolean => {
-  // None of a peer's addresses match public
-  return !(peer.multiaddrs.toArray().filter((ma) => ma.nodeAddress().address.match(PRIVATE_NETS)).length > 0)
-}
 
 class Crawler<Chain extends HoprCoreConnector> {
   constructor(

--- a/src/network/transport/index.ts
+++ b/src/network/transport/index.ts
@@ -36,7 +36,6 @@ import upgradeToWebRTC from './webrtc'
 
 import Relay from './relay'
 
-const PRIVATE_NETS = /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/
 /**
  * @class TCP
  */

--- a/src/network/transport/index.ts
+++ b/src/network/transport/index.ts
@@ -215,12 +215,17 @@ class TCP {
       this._peerInfo.multiaddrs
         .toArray()
         .map((x) => x.nodeAddress())
-        .filter((x) => x.address == ma.nodeAddress().address) // Same private network
+        .filter(
+          (x) =>
+            x.address == ma.nodeAddress().address || // Same private network
+            ma.nodeAddress().address == '127.0.0.1' // localhost
+        )
         .filter((x) => x.port == ma.nodeAddress().port).length // Same port // Therefore dialing self.
     ) {
       log(`Tried to dial host on same network / port - aborting: ${ma.toString()}`)
       return false
     }
+
     return true
   }
 
@@ -233,7 +238,7 @@ class TCP {
    */
   async dial(ma: Multiaddr, options?: DialOptions): Promise<Connection> {
     if (!this.filterUnrealisticAddresses(ma)) {
-      return new Promise((r, x) => x('Filtering unrealistic address'))
+      return new Promise((r, x) => x(new Error('Filtering unrealistic address')))
     }
 
     options = options || {}

--- a/src/network/transport/index.ts
+++ b/src/network/transport/index.ts
@@ -212,17 +212,15 @@ class TCP {
       return false
     }
 
-    if (ma.nodeAddress().address.match(PRIVATE_NETS)) {
-      if (
-        this._peerInfo.multiaddrs
-          .toArray()
-          .map((x) => x.nodeAddress())
-          .filter((x) => x.address == ma.nodeAddress().address) // Same private network
-          .filter((x) => x.port == ma.nodeAddress().port).length // Same port // Therefore dialing self.
-      ) {
-        log(`Tried to dial host on same private net / port - aborting: ${ma.toString()}`)
-        return false
-      }
+    if (
+      this._peerInfo.multiaddrs
+        .toArray()
+        .map((x) => x.nodeAddress())
+        .filter((x) => x.address == ma.nodeAddress().address) // Same private network
+        .filter((x) => x.port == ma.nodeAddress().port).length // Same port // Therefore dialing self.
+    ) {
+      log(`Tried to dial host on same network / port - aborting: ${ma.toString()}`)
+      return false
     }
     return true
   }
@@ -240,13 +238,6 @@ class TCP {
     }
 
     options = options || {}
-
-    if (ma.getPeerId() === this._peerInfo.id.toB58String()) {
-      // Somehow we can get in the situation where we have our own id as the
-      // remote peer - we should filter these out (and also TODO find out why)
-      log('Tried to dial self, skipping.')
-      return new Promise((r, x) => x('Not going to dial self'))
-    }
 
     let error: Error
     if (['ip4', 'ip6', 'dns4', 'dns6'].includes(ma.protoNames()[0])) {


### PR DESCRIPTION
This prevents the following scenarios.


(1)
- We crawl a host on a remote network
- That node has a list of nodes that are on it's private network
- We receive these and look for them on the same private address
  on our unrelated network.

(2)
- Somehow I am dialing myself (address/port) with a same or different id

(3)
- I am dialing someone else, with my ID
